### PR TITLE
Change JSON::XS to JSON::MaybeXS

### DIFF
--- a/META.json
+++ b/META.json
@@ -38,7 +38,7 @@
       },
       "runtime" : {
          "requires" : {
-            "JSON::XS" : "0",
+            "JSON::MaybeXS" : "0",
             "Scalar::Util" : "0",
             "perl" : "5.010001"
          }

--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires 'perl', '5.010001';
 
-requires 'JSON::XS';
+requires 'JSON::MaybeXS';
 requires 'Scalar::Util';
 
 on configure => sub {

--- a/lib/JSON/RPC2/Client.pm
+++ b/lib/JSON/RPC2/Client.pm
@@ -7,7 +7,7 @@ use Carp;
 
 our $VERSION = 'v2.0.0';
 
-use JSON::XS;
+use JSON::MaybeXS;
 use Scalar::Util qw( weaken refaddr );
 
 

--- a/lib/JSON/RPC2/Server.pm
+++ b/lib/JSON/RPC2/Server.pm
@@ -7,7 +7,7 @@ use Carp;
 
 our $VERSION = 'v2.0.0';
 
-use JSON::XS;
+use JSON::MaybeXS;
 
 use constant ERR_PARSE  => -32700;
 use constant ERR_REQ    => -32600;

--- a/t/blocking_hashref.t
+++ b/t/blocking_hashref.t
@@ -2,7 +2,7 @@ use Test::More tests => 17;
 
 use JSON::RPC2::Server;
 use JSON::RPC2::Client;
-use JSON::XS;
+use JSON::MaybeXS;
 
 
 my $server = JSON::RPC2::Server->new();

--- a/t/share.pm
+++ b/t/share.pm
@@ -2,7 +2,7 @@ use warnings;
 use strict;
 use Test::More;
 use Test::Exception;
-use JSON::XS qw( decode_json encode_json );
+use JSON::MaybeXS qw( decode_json encode_json );
 
 use JSON::RPC2::Client;
 use JSON::RPC2::Server;


### PR DESCRIPTION
I love this distribution and use it in multiple project. The only issue, and it's a minor one, is that in one of those projects I need to use Cpanel::JSON::XS for some compatability reasons, which results in different pieces of the code using different JSON serializers. I also have a project that it'd be nice to able to JSON::RPC2 with JSON::PP for fatpacking.

So, barely an issue, but easily resolved by using JSON::MaybeXS, which has the benefit of allowing some level of control by the user over which serializer is selected.
